### PR TITLE
sync crypto

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,11 +1,10 @@
-// () => import doesn't work with crypto
-const crypto = import('crypto');
+import crypto from 'crypto'
 
 // const moment = () => import('moment');
 import { formatDistance, fromUnixTime, getUnixTime } from 'date-fns' 
 
-export const md5 = str => {
-    return crypto.then((m) => m.createHash('md5').update(str).digest("hex"));
+export const md5 = (str) => {
+    return crypto.createHash('md5').update(str).digest("hex")
 }
 
 export const  cgravatar = (email) => {


### PR DESCRIPTION
using dynamic import for crypto was causing issues with the md5 function.
it is not a very important requirement that crypto be a dynamic import for now so reverting that import to regular import for now